### PR TITLE
[Feature] Navigation bar layout

### DIFF
--- a/addon/components/slds-navigation-bar.js
+++ b/addon/components/slds-navigation-bar.js
@@ -3,5 +3,6 @@ import layout from '../templates/components/slds-navigation-bar';
 
 export default Ember.Component.extend({
   layout,
-  applicationName: 'App Name'
+  applicationName: 'App Name',
+  contextBarSecondaryComponent: 'slds-navigation-bar/context-bar-secondary'
 });

--- a/addon/components/slds-navigation-bar/context-bar-secondary.js
+++ b/addon/components/slds-navigation-bar/context-bar-secondary.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+import layout from '../../templates/components/slds-navigation-bar/context-bar-secondary';
+
+export default Ember.Component.extend({
+  layout,
+  tagName: ''
+});

--- a/addon/templates/components/slds-navigation-bar.hbs
+++ b/addon/templates/components/slds-navigation-bar.hbs
@@ -12,12 +12,10 @@
       </span>
     </div>
   </div>
-  <nav class="slds-context-bar__secondary" role="navigation">
-    <ul class="slds-grid">
-      {{yield (hash 
-        item=(component 'slds-navigation-bar/item')
-        menu=(component 'slds-navigation-bar/menu')
-      )}}
-    </ul>
-  </nav>
+  {{#component contextBarSecondaryComponent}}
+    {{yield (hash
+      item=(component 'slds-navigation-bar/item')
+      menu=(component 'slds-navigation-bar/menu')
+    )}}
+  {{/component}}
 </div>

--- a/addon/templates/components/slds-navigation-bar/context-bar-secondary.hbs
+++ b/addon/templates/components/slds-navigation-bar/context-bar-secondary.hbs
@@ -1,0 +1,5 @@
+  <nav class="slds-context-bar__secondary" role="navigation">
+    <ul class="slds-grid">
+      {{yield}}
+    </ul>
+  </nav>

--- a/app/components/slds-navigation-bar/context-bar-secondary.js
+++ b/app/components/slds-navigation-bar/context-bar-secondary.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-lightning-design-system/components/slds-navigation-bar/context-bar-secondary';

--- a/tests/integration/components/slds-navigation-bar/context-bar-secondary-test.js
+++ b/tests/integration/components/slds-navigation-bar/context-bar-secondary-test.js
@@ -1,0 +1,28 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent(
+  'slds-navigation-bar/context-bar-secondary',
+  'Integration | Component | slds navigation bar/context bar secondary',
+  {
+    integration: true
+  }
+);
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{slds-navigation-bar/context-bar-secondary}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#slds-navigation-bar/context-bar-secondary}}
+      template block text
+    {{/slds-navigation-bar/context-bar-secondary}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
@thingylab this looks complicated, but what it lets you do is:

```hbs
{{#slds-navigation-bar 
   contextBarSecondaryComponent=(component '... your own layout component here...') as |bar|}}
  {{bar.item}}
{{/slds-navigation-bar}}
```

You would need to make your own component for the layout, so something like:

```
ember g component slds-navigation-bar/layout-with-text
```

with the following content:

```
<nav class="slds-context-bar__secondary" role="navigation">
  <ul class="slds-grid">
    {{yield}}
  </ul>
</nav>
look at my cool text!! 
```

make sure to set the `tagName` to an empty string so that it doesn't insert more dom which could mess with the css. 